### PR TITLE
🔒 Fix alpha-blocking issues before launch

### DIFF
--- a/app.fuggs.fuggs-app/pom.xml
+++ b/app.fuggs.fuggs-app/pom.xml
@@ -71,6 +71,10 @@
             <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.amazonservices</groupId>
             <artifactId>quarkus-amazon-s3</artifactId>
         </dependency>

--- a/app.fuggs.fuggs-app/src/main/java/app/fuggs/invitation/api/InvitationResource.java
+++ b/app.fuggs.fuggs-app/src/main/java/app/fuggs/invitation/api/InvitationResource.java
@@ -62,9 +62,11 @@ public class InvitationResource extends Controller
 		}
 
 		public static native TemplateInstance index(List<Invitation> pendingInvitations,
-			List<Invitation> acceptedInvitations, List<Invitation> expiredInvitations);
+			List<Invitation> acceptedInvitations, List<Invitation> expiredInvitations, boolean isSuperAdmin);
 
 		public static native TemplateInstance create();
+
+		public static native TemplateInstance createFounder();
 	}
 
 	@GET
@@ -80,7 +82,7 @@ public class InvitationResource extends Controller
 		List<Invitation> expired = invitationRepository.findByOrganizationAndStatus(currentOrg,
 			InvitationStatus.EXPIRED);
 
-		return Templates.index(pending, accepted, expired);
+		return Templates.index(pending, accepted, expired, securityIdentity.hasRole(Roles.SUPER_ADMIN));
 	}
 
 	@GET
@@ -147,6 +149,76 @@ public class InvitationResource extends Controller
 		catch (Exception e)
 		{
 			LOG.error("Failed to create invitation: email={}, error={}", email, e.getMessage(), e);
+			flash(FlashKeys.ERROR, "Fehler beim Erstellen der Einladung: " + e.getMessage());
+		}
+
+		redirect(InvitationResource.class).index();
+	}
+
+	/**
+	 * Show form to create a founder invitation (super admin only). Founder
+	 * invitations have no pre-assigned organization — the invitee creates their
+	 * own org during registration.
+	 */
+	@GET
+	@Path("/founder")
+	@RolesAllowed(Roles.SUPER_ADMIN)
+	public TemplateInstance createFounder()
+	{
+		return Templates.createFounder();
+	}
+
+	/**
+	 * Create a founder invitation (super admin only).
+	 */
+	@POST
+	@Path("/founder")
+	@RolesAllowed(Roles.SUPER_ADMIN)
+	@Transactional
+	public void createFounderInvitation(@RestForm String email)
+	{
+		if (validationFailed())
+		{
+			redirect(InvitationResource.class).createFounder();
+			return;
+		}
+
+		Member currentMember = memberRepository.findByUsername(securityIdentity.getPrincipal().getName());
+		if (currentMember == null)
+		{
+			LOG.error("Current member not found: username={}", securityIdentity.getPrincipal().getName());
+			flash(FlashKeys.ERROR, "Fehler: Benutzer nicht gefunden");
+			redirect(InvitationResource.class).index();
+			return;
+		}
+
+		// Check if email already has a pending invitation
+		Invitation existingInvitation = invitationRepository.findPendingByEmail(email);
+		if (existingInvitation != null)
+		{
+			flash(FlashKeys.WARNING, "Es existiert bereits eine ausstehende Einladung für diese E-Mail-Adresse");
+			redirect(InvitationResource.class).index();
+			return;
+		}
+
+		// Check if email already belongs to a member
+		Member existingMember = memberRepository.findByEmail(email);
+		if (existingMember != null)
+		{
+			flash(FlashKeys.ERROR, "Ein Benutzer mit dieser E-Mail-Adresse existiert bereits");
+			redirect(InvitationResource.class).createFounder();
+			return;
+		}
+
+		try
+		{
+			Invitation invitation = invitationService.createFounderInvitation(email, currentMember);
+			LOG.info("Founder invitation created: id={}, email={}", invitation.id, email);
+			flash(FlashKeys.SUCCESS, "Gründer-Einladung erstellt für " + email);
+		}
+		catch (Exception e)
+		{
+			LOG.error("Failed to create founder invitation: email={}, error={}", email, e.getMessage(), e);
 			flash(FlashKeys.ERROR, "Fehler beim Erstellen der Einladung: " + e.getMessage());
 		}
 

--- a/app.fuggs.fuggs-app/src/main/java/app/fuggs/invitation/service/EmailService.java
+++ b/app.fuggs.fuggs-app/src/main/java/app/fuggs/invitation/service/EmailService.java
@@ -80,14 +80,15 @@ public class EmailService
 
 		String registrationUrl = baseUrl + "/registrierung?token=" + token;
 		String roleDisplay = role.equals("ADMIN") ? "Administrator" : "Mitglied";
-		String subject = "Einladung zu " + organizationName;
+		String displayOrgName = organizationName != null ? organizationName : "Fuggs Buchhaltung";
+		String subject = "Einladung zu " + displayOrgName;
 
 		try
 		{
 			// Render HTML and text templates
-			String htmlBody = Templates.invitationHtml(organizationName, inviterName, roleDisplay, registrationUrl)
+			String htmlBody = Templates.invitationHtml(displayOrgName, inviterName, roleDisplay, registrationUrl)
 				.render();
-			String textBody = Templates.invitationText(organizationName, inviterName, roleDisplay, registrationUrl)
+			String textBody = Templates.invitationText(displayOrgName, inviterName, roleDisplay, registrationUrl)
 				.render();
 
 			// Send email via SMTP

--- a/app.fuggs.fuggs-app/src/main/java/app/fuggs/invitation/service/InvitationService.java
+++ b/app.fuggs.fuggs-app/src/main/java/app/fuggs/invitation/service/InvitationService.java
@@ -33,7 +33,8 @@ public class InvitationService
 	EmailService emailService;
 
 	/**
-	 * Creates a new invitation with a unique token.
+	 * Creates a new invitation with a unique token for an existing
+	 * organization.
 	 *
 	 * @param email
 	 *            The invitee's email address
@@ -51,10 +52,45 @@ public class InvitationService
 		LOG.info("Creating invitation: email={}, role={}, organizationId={}, invitedBy={}", email, role,
 			organization.id, invitedBy.getDisplayName());
 
-		// Generate unique token
+		Invitation invitation = buildInvitation(email, role, organization, invitedBy);
+		invitationRepository.persist(invitation);
+
+		LOG.info("Invitation created: id={}, token={}, email={}", invitation.id, invitation.getToken(), email);
+
+		sendEmailQuietly(invitation, organization.getDisplayName(), invitedBy.getDisplayName());
+
+		return invitation;
+	}
+
+	/**
+	 * Creates a founder invitation with no pre-assigned organization. The
+	 * invitee will create their own organization during registration.
+	 *
+	 * @param email
+	 *            The invitee's email address
+	 * @param invitedBy
+	 *            The super-admin member creating the invitation
+	 * @return The created invitation
+	 */
+	@Transactional
+	public Invitation createFounderInvitation(String email, Member invitedBy)
+	{
+		LOG.info("Creating founder invitation: email={}, invitedBy={}", email, invitedBy.getDisplayName());
+
+		Invitation invitation = buildInvitation(email, InvitationRole.ADMIN, null, invitedBy);
+		invitationRepository.persist(invitation);
+
+		LOG.info("Founder invitation created: id={}, token={}, email={}", invitation.id, invitation.getToken(), email);
+
+		sendEmailQuietly(invitation, null, invitedBy.getDisplayName());
+
+		return invitation;
+	}
+
+	private Invitation buildInvitation(String email, InvitationRole role, Organization organization, Member invitedBy)
+	{
 		String token = UUID.randomUUID().toString();
 
-		// Create invitation
 		Invitation invitation = new Invitation();
 		invitation.setEmail(email);
 		invitation.setToken(token);
@@ -64,25 +100,23 @@ public class InvitationService
 		invitation.setInvitedBy(invitedBy);
 		invitation.setExpiresAt(Instant.now().plus(EXPIRATION_DAYS, ChronoUnit.DAYS));
 
-		invitationRepository.persist(invitation);
+		return invitation;
+	}
 
-		LOG.info("Invitation created: id={}, token={}, email={}", invitation.id, token, email);
-
-		// Send invitation email
+	private void sendEmailQuietly(Invitation invitation, String organizationName, String inviterName)
+	{
 		try
 		{
-			emailService.sendInvitationEmail(email, token, organization.getDisplayName(), invitedBy.getDisplayName(),
-				role.name());
-			LOG.info("Invitation email sent: id={}, email={}", invitation.id, email);
+			emailService.sendInvitationEmail(invitation.getEmail(), invitation.getToken(), organizationName,
+				inviterName, invitation.getRole().name());
+			LOG.info("Invitation email sent: id={}, email={}", invitation.id, invitation.getEmail());
 		}
 		catch (Exception e)
 		{
-			LOG.error("Failed to send invitation email: id={}, email={}, error={}", invitation.id, email,
-				e.getMessage(), e);
+			LOG.error("Failed to send invitation email: id={}, email={}, error={}", invitation.id,
+				invitation.getEmail(), e.getMessage(), e);
 			// Continue - invitation is still created even if email fails
 		}
-
-		return invitation;
 	}
 
 	/**
@@ -208,8 +242,11 @@ public class InvitationService
 		// Send invitation email
 		try
 		{
+			String organizationName = invitation.getOrganization() != null
+				? invitation.getOrganization().getDisplayName()
+				: null;
 			emailService.sendInvitationEmail(invitation.getEmail(), invitation.getToken(),
-				invitation.getOrganization().getDisplayName(), invitation.getInvitedBy().getDisplayName(),
+				organizationName, invitation.getInvitedBy().getDisplayName(),
 				invitation.getRole().name());
 			LOG.info("Invitation email resent successfully: id={}, email={}", invitation.id, invitation.getEmail());
 		}

--- a/app.fuggs.fuggs-app/src/main/java/app/fuggs/invitation/service/RegistrationService.java
+++ b/app.fuggs.fuggs-app/src/main/java/app/fuggs/invitation/service/RegistrationService.java
@@ -7,6 +7,7 @@ import app.fuggs.member.repository.MemberRepository;
 import app.fuggs.member.service.KeycloakAdminService;
 import app.fuggs.organization.domain.Organization;
 import app.fuggs.organization.repository.OrganizationRepository;
+import app.fuggs.shared.bootstrap.BootstrapService;
 import app.fuggs.shared.security.Roles;
 import app.fuggs.shared.util.SlugUtil;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -34,6 +35,9 @@ public class RegistrationService
 
 	@Inject
 	KeycloakAdminService keycloakAdminService;
+
+	@Inject
+	BootstrapService bootstrapService;
 
 	/**
 	 * Registers a new founder user with a new organization.
@@ -72,7 +76,7 @@ public class RegistrationService
 
 		// Create Keycloak user with ADMIN and MEMBER roles
 		String keycloakUserId = keycloakAdminService.createUser(member.getUserName(), member.getEmail(),
-			member.getFirstName(), member.getLastName(), List.of(Roles.ADMIN, Roles.MEMBER));
+			member.getFirstName(), member.getLastName(), List.of(Roles.ADMIN, Roles.MEMBER), data.getPassword());
 
 		member.setKeycloakUserId(keycloakUserId);
 		memberRepository.persist(member);
@@ -126,7 +130,7 @@ public class RegistrationService
 
 		// Create Keycloak user
 		String keycloakUserId = keycloakAdminService.createUser(member.getUserName(), member.getEmail(),
-			member.getFirstName(), member.getLastName(), roles);
+			member.getFirstName(), member.getLastName(), roles, data.getPassword());
 
 		member.setKeycloakUserId(keycloakUserId);
 		memberRepository.persist(member);
@@ -161,6 +165,7 @@ public class RegistrationService
 		organization.setActive(true);
 
 		organizationRepository.persist(organization);
+		bootstrapService.ensureRootBommel(organization);
 
 		LOG.info("Organization created: id={}, slug={}, name={}", organization.id, slug, name);
 

--- a/app.fuggs.fuggs-app/src/main/java/app/fuggs/member/service/KeycloakAdminService.java
+++ b/app.fuggs.fuggs-app/src/main/java/app/fuggs/member/service/KeycloakAdminService.java
@@ -28,12 +28,18 @@ public class KeycloakAdminService
 	String realm;
 
 	public String createUser(String username, String email, String firstName,
-		String lastName, List<String> roles)
+		String lastName, List<String> roles, String password)
+	{
+		return createUser(username, email, firstName, lastName, roles, password, false);
+	}
+
+	public String createUser(String username, String email, String firstName,
+		String lastName, List<String> roles, String password, boolean temporary)
 	{
 		CredentialRepresentation credential = new CredentialRepresentation();
 		credential.setType(CredentialRepresentation.PASSWORD);
-		credential.setValue("password"); // Default password
-		credential.setTemporary(false);
+		credential.setValue(password);
+		credential.setTemporary(temporary);
 
 		UserRepresentation user = new UserRepresentation();
 		user.setUsername(username);
@@ -41,12 +47,7 @@ public class KeycloakAdminService
 		user.setFirstName(firstName);
 		user.setLastName(lastName);
 		user.setEnabled(true);
-		// TODO: Implement proper email verification flow
-		// For now, keeping emailVerified=false for security. Users created via
-		// bootstrap are for dev/test and don't need verification, but
-		// production
-		// users should verify.
-		user.setEmailVerified(false);
+		user.setEmailVerified(true);
 		user.setCredentials(Collections.singletonList(credential));
 
 		Response response = keycloak.realm(realm).users().create(user);

--- a/app.fuggs.fuggs-app/src/main/java/app/fuggs/member/service/MemberKeycloakSyncService.java
+++ b/app.fuggs.fuggs-app/src/main/java/app/fuggs/member/service/MemberKeycloakSyncService.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @ApplicationScoped
 public class MemberKeycloakSyncService
@@ -29,12 +30,17 @@ public class MemberKeycloakSyncService
 		LOG.info("Syncing member to Keycloak: memberId={}, username={}, roles={}",
 			member.getId(), username, roles);
 
+		// Admin-created members get a random temporary password; Keycloak will
+		// prompt them to set a new one on first login.
+		String tempPassword = UUID.randomUUID().toString();
 		String keycloakUserId = keycloakAdminService.createUser(
 			username,
 			member.getEmail(),
 			member.getFirstName(),
 			member.getLastName(),
-			roles);
+			roles,
+			tempPassword,
+			true);
 
 		LOG.info("Member synced to Keycloak: memberId={}, keycloakUserId={}",
 			member.getId(), keycloakUserId);

--- a/app.fuggs.fuggs-app/src/main/java/app/fuggs/organization/api/OrganizationResource.java
+++ b/app.fuggs.fuggs-app/src/main/java/app/fuggs/organization/api/OrganizationResource.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import app.fuggs.dashboard.api.DashboardResource;
 import app.fuggs.organization.domain.Organization;
 import app.fuggs.organization.repository.OrganizationRepository;
+import app.fuggs.shared.bootstrap.BootstrapService;
 import app.fuggs.shared.security.OrganizationContext;
 import io.quarkiverse.renarde.Controller;
 import io.quarkus.qute.CheckedTemplate;
@@ -39,6 +40,9 @@ public class OrganizationResource extends Controller
 
 	@Inject
 	OrganizationContext organizationContext;
+
+	@Inject
+	BootstrapService bootstrapService;
 
 	@CheckedTemplate
 	public static class Templates
@@ -107,6 +111,7 @@ public class OrganizationResource extends Controller
 		organization.setActive(true);
 
 		organizationRepository.persist(organization);
+		bootstrapService.ensureRootBommel(organization);
 
 		LOG.info("Organization created: {} ({})", organization.getName(), organization.getSlug());
 		flash(FlashKeys.SUCCESS, "Organisation erfolgreich erstellt");

--- a/app.fuggs.fuggs-app/src/main/java/app/fuggs/shared/bootstrap/BootstrapService.java
+++ b/app.fuggs.fuggs-app/src/main/java/app/fuggs/shared/bootstrap/BootstrapService.java
@@ -81,6 +81,9 @@ public class BootstrapService
 	@ConfigProperty(name = "fuggs.bootstrap.users.admin.organization")
 	String adminOrganization;
 
+	@ConfigProperty(name = "fuggs.bootstrap.users.admin.password", defaultValue = "password")
+	String adminPassword;
+
 	// User 2: Maria config
 	@ConfigProperty(name = "fuggs.bootstrap.users.maria.username")
 	String mariaUsername;
@@ -99,6 +102,9 @@ public class BootstrapService
 
 	@ConfigProperty(name = "fuggs.bootstrap.users.maria.organization")
 	String mariaOrganization;
+
+	@ConfigProperty(name = "fuggs.bootstrap.users.maria.password", defaultValue = "password")
+	String mariaPassword;
 
 	// User 3: Thomas config
 	@ConfigProperty(name = "fuggs.bootstrap.users.thomas.username")
@@ -119,11 +125,14 @@ public class BootstrapService
 	@ConfigProperty(name = "fuggs.bootstrap.users.thomas.organization")
 	String thomasOrganization;
 
+	@ConfigProperty(name = "fuggs.bootstrap.users.thomas.password", defaultValue = "password")
+	String thomasPassword;
+
 	/**
 	 * User configuration record for bootstrapping users.
 	 */
 	private record UserConfig(String username, String email, String firstName, String lastName,
-		List<String> roles, String organizationSlug)
+		List<String> roles, String organizationSlug, String password)
 	{
 	}
 
@@ -162,11 +171,11 @@ public class BootstrapService
 
 		// Create user configs
 		List<UserConfig> users = List.of(new UserConfig(adminUsername, adminEmail, adminFirstName,
-			adminLastName, adminRoles, adminOrganization),
+			adminLastName, adminRoles, adminOrganization, adminPassword),
 			new UserConfig(mariaUsername, mariaEmail, mariaFirstName, mariaLastName, mariaRoles,
-				mariaOrganization),
+				mariaOrganization, mariaPassword),
 			new UserConfig(thomasUsername, thomasEmail, thomasFirstName, thomasLastName, thomasRoles,
-				thomasOrganization));
+				thomasOrganization, thomasPassword));
 
 		// Bootstrap each user
 		for (UserConfig userConfig : users)
@@ -236,7 +245,7 @@ public class BootstrapService
 		try
 		{
 			String newUserId = keycloakAdminService.createUser(config.username(), config.email(),
-				config.firstName(), config.lastName(), config.roles());
+				config.firstName(), config.lastName(), config.roles(), config.password());
 			LOG.info("Created Keycloak user: {} (id: {})", config.username(), newUserId);
 			return newUserId;
 		}

--- a/app.fuggs.fuggs-app/src/main/resources/application.properties
+++ b/app.fuggs.fuggs-app/src/main/resources/application.properties
@@ -11,7 +11,11 @@ quarkus.http.non-application-root-path=/q
 # Database / Hibernate
 ########################################
 # DevServices will automatically start PostgreSQL in dev mode
-quarkus.hibernate-orm.database.generation=drop-and-create
+%dev.quarkus.hibernate-orm.database.generation=drop-and-create
+%test.quarkus.hibernate-orm.database.generation=drop-and-create
+# Production: Flyway manages the schema; Hibernate must not touch it
+%prod.quarkus.hibernate-orm.database.generation=none
+%prod.quarkus.flyway.migrate-at-start=true
 quarkus.hibernate-orm.mapping.format.global=ignore
 
 ########################################
@@ -107,6 +111,7 @@ fuggs.bootstrap.users.admin.first-name=Super
 fuggs.bootstrap.users.admin.last-name=Admin
 fuggs.bootstrap.users.admin.roles=super_admin,admin,user
 fuggs.bootstrap.users.admin.organization=musikverein-harmonie
+fuggs.bootstrap.users.admin.password=password
 
 # User 2: Admin (Org A)
 fuggs.bootstrap.users.maria.username=maria
@@ -115,6 +120,7 @@ fuggs.bootstrap.users.maria.first-name=Maria
 fuggs.bootstrap.users.maria.last-name=Schmidt
 fuggs.bootstrap.users.maria.roles=admin,user
 fuggs.bootstrap.users.maria.organization=musikverein-harmonie
+fuggs.bootstrap.users.maria.password=password
 
 # User 3: Regular User (Org B)
 fuggs.bootstrap.users.thomas.username=thomas
@@ -123,3 +129,14 @@ fuggs.bootstrap.users.thomas.first-name=Thomas
 fuggs.bootstrap.users.thomas.last-name=Müller
 fuggs.bootstrap.users.thomas.roles=user
 fuggs.bootstrap.users.thomas.organization=sportverein-alpenblick
+fuggs.bootstrap.users.thomas.password=password
+
+########################################
+# Production Overrides
+########################################
+# In production, override via environment variables:
+#   FUGGS_BOOTSTRAP_ORG_A_NAME, FUGGS_BOOTSTRAP_ORG_A_SLUG, FUGGS_BOOTSTRAP_ORG_A_DISPLAY_NAME
+#   FUGGS_BOOTSTRAP_USERS_ADMIN_USERNAME, _EMAIL, _FIRST_NAME, _LAST_NAME, _ORGANIZATION, _PASSWORD
+#   FUGGS_BOOTSTRAP_USERS_MARIA_USERNAME (set same as admin to skip), _PASSWORD, ...
+#   FUGGS_BOOTSTRAP_USERS_THOMAS_USERNAME (set same as admin to skip), _PASSWORD, ...
+# SMTP_HOST, SMTP_PORT, SMTP_USERNAME, SMTP_PASSWORD, APP_BASE_URL, APP_FROM_EMAIL

--- a/app.fuggs.fuggs-app/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/app.fuggs.fuggs-app/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,187 @@
+-- V1: Initial schema
+-- Derived from JPA entities (Hibernate 6 / Quarkus 3.x naming conventions)
+-- Column names use snake_case (CamelCaseToUnderscoresNamingStrategy)
+
+-- Shared sequence used by Hibernate for all entity IDs
+CREATE SEQUENCE IF NOT EXISTS hibernate_sequence START WITH 1 INCREMENT BY 50;
+
+-- ============================================================
+-- organization
+-- ============================================================
+CREATE TABLE organization
+(
+    id           BIGINT                      NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    name         VARCHAR(255)                NOT NULL UNIQUE,
+    slug         VARCHAR(255)                NOT NULL UNIQUE,
+    display_name VARCHAR(255),
+    description  VARCHAR(255),
+    active       BOOLEAN                     NOT NULL             DEFAULT TRUE,
+    created_at   TIMESTAMP WITH TIME ZONE    NOT NULL
+);
+
+-- ============================================================
+-- member
+-- ============================================================
+CREATE TABLE member
+(
+    id                   BIGINT       NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    first_name           VARCHAR(255),
+    last_name            VARCHAR(255),
+    email                VARCHAR(255),
+    phone                VARCHAR(255),
+    user_name            VARCHAR(255) UNIQUE,
+    organization_id      BIGINT       NOT NULL REFERENCES organization (id),
+    keycloak_user_id     VARCHAR(255) UNIQUE,
+    invited_by_member_id BIGINT,
+    invite_type          VARCHAR(20),
+    joined_at            TIMESTAMP WITH TIME ZONE
+);
+
+-- ============================================================
+-- bommel
+-- ============================================================
+CREATE TABLE bommel
+(
+    id                    BIGINT       NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    icon                  VARCHAR(255),
+    title                 VARCHAR(255),
+    parent_id             BIGINT REFERENCES bommel (id),
+    responsible_member_id BIGINT REFERENCES member (id),
+    organization_id       BIGINT       NOT NULL REFERENCES organization (id)
+);
+
+-- ============================================================
+-- tag
+-- ============================================================
+CREATE TABLE tag
+(
+    id              BIGINT       NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    organization_id BIGINT       NOT NULL REFERENCES organization (id),
+    name            VARCHAR(255) NOT NULL,
+    UNIQUE (organization_id, name)
+);
+
+-- ============================================================
+-- tradeparty
+-- ============================================================
+CREATE TABLE tradeparty
+(
+    id                 BIGINT       NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    organization_id    BIGINT       NOT NULL REFERENCES organization (id),
+    name               VARCHAR(255),
+    country            VARCHAR(255),
+    state              VARCHAR(255),
+    city               VARCHAR(255),
+    zip_code           VARCHAR(255),
+    street             VARCHAR(255),
+    additional_address VARCHAR(255),
+    tax_id             VARCHAR(255),
+    vat_id             VARCHAR(255)
+);
+
+-- ============================================================
+-- document
+-- ============================================================
+CREATE TABLE document
+(
+    id                BIGINT                   NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    organization_id   BIGINT                   NOT NULL REFERENCES organization (id),
+    bommel_id         BIGINT REFERENCES bommel (id),
+    sender_id         BIGINT REFERENCES tradeparty (id),
+    recipient_id      BIGINT REFERENCES tradeparty (id),
+    name              VARCHAR(255),
+    total             NUMERIC                  NOT NULL,
+    currency_code     VARCHAR(255),
+    transaction_time  TIMESTAMP WITH TIME ZONE,
+    privately_paid    BOOLEAN                           DEFAULT FALSE,
+    total_tax         NUMERIC,
+    file_key          VARCHAR(255),
+    file_name         VARCHAR(255),
+    file_content_type VARCHAR(255),
+    file_size         BIGINT,
+    analysis_status   VARCHAR(255),
+    analysis_error    VARCHAR(255),
+    extraction_source VARCHAR(255),
+    document_status   VARCHAR(255),
+    flow_id           VARCHAR(255),
+    uploaded_by       VARCHAR(255),
+    analyzed_by       VARCHAR(255),
+    reviewed_by       VARCHAR(255),
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- ============================================================
+-- document_tag
+-- ============================================================
+CREATE TABLE document_tag
+(
+    id          BIGINT NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    document_id BIGINT NOT NULL REFERENCES document (id),
+    tag_id      BIGINT NOT NULL REFERENCES tag (id),
+    source      VARCHAR(255),
+    UNIQUE (document_id, tag_id)
+);
+
+-- ============================================================
+-- transactionrecord
+-- ============================================================
+CREATE TABLE transactionrecord
+(
+    id               BIGINT                   NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    organization_id  BIGINT                   NOT NULL REFERENCES organization (id),
+    bommel_id        BIGINT REFERENCES bommel (id),
+    document_id      BIGINT REFERENCES document (id),
+    sender_id        BIGINT REFERENCES tradeparty (id),
+    recipient_id     BIGINT REFERENCES tradeparty (id),
+    uploader         VARCHAR(255)             NOT NULL,
+    total            NUMERIC                  NOT NULL,
+    privately_paid   BOOLEAN                  NOT NULL             DEFAULT FALSE,
+    transaction_time TIMESTAMP WITH TIME ZONE,
+    name             VARCHAR(255),
+    currency_code    VARCHAR(255),
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- ============================================================
+-- transaction_tag
+-- ============================================================
+CREATE TABLE transaction_tag
+(
+    id                  BIGINT NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    transaction_record_id BIGINT NOT NULL REFERENCES transactionrecord (id),
+    tag_id              BIGINT NOT NULL REFERENCES tag (id),
+    source              VARCHAR(255),
+    UNIQUE (transaction_record_id, tag_id)
+);
+
+-- ============================================================
+-- invitation
+-- ============================================================
+CREATE TABLE invitation
+(
+    id              BIGINT                   NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    token           VARCHAR(36)              NOT NULL UNIQUE,
+    email           VARCHAR(255)             NOT NULL,
+    organization_id BIGINT REFERENCES organization (id),
+    role            VARCHAR(255)             NOT NULL,
+    status          VARCHAR(255)             NOT NULL,
+    expires_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+    invited_by_id   BIGINT                   NOT NULL REFERENCES member (id),
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+    accepted_at     TIMESTAMP WITH TIME ZONE
+);
+
+-- ============================================================
+-- auditlogentry
+-- ============================================================
+CREATE TABLE auditlogentry
+(
+    id              BIGINT                   NOT NULL PRIMARY KEY DEFAULT nextval('hibernate_sequence'),
+    organization_id BIGINT                   NOT NULL REFERENCES organization (id),
+    username        VARCHAR(255),
+    timestamp       TIMESTAMP WITH TIME ZONE NOT NULL,
+    task_name       VARCHAR(255),
+    details         VARCHAR(4000),
+    entity_name     VARCHAR(255),
+    entity_id       VARCHAR(255)
+);

--- a/app.fuggs.fuggs-app/src/main/resources/templates/InvitationResource/createFounder.html
+++ b/app.fuggs.fuggs-app/src/main/resources/templates/InvitationResource/createFounder.html
@@ -1,0 +1,94 @@
+{#include main.html}
+{#title}Gründer einladen - Fuggs Buchhaltung{/title}
+
+{#moreStyles}
+<style>
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--cds-spacing-05);
+  }
+  .page-header h1 {
+    margin: 0;
+  }
+  .form-container {
+    max-width: 600px;
+  }
+  .form-section {
+    margin-bottom: var(--cds-spacing-07);
+  }
+  .form-actions {
+    display: flex;
+    gap: var(--cds-spacing-05);
+    margin-top: var(--cds-spacing-07);
+  }
+  .info-box {
+    background: #d0e2ff;
+    border-left: 4px solid #0f62fe;
+    padding: var(--cds-spacing-05);
+    margin-bottom: var(--cds-spacing-07);
+    border-radius: 4px;
+  }
+  .info-box h3 {
+    margin: 0 0 var(--cds-spacing-03) 0;
+    color: #0043ce;
+    font-size: 1rem;
+  }
+  .info-box p {
+    margin: 0;
+    color: #0043ce;
+    font-size: 0.875rem;
+  }
+</style>
+{/moreStyles}
+
+<div class="page-header">
+  <h1>Gründer einladen</h1>
+  <cds-button href="/einladungen" kind="secondary">
+    Zurück zur Übersicht
+  </cds-button>
+</div>
+
+<div class="box form-container">
+  <div class="info-box">
+    <h3>Neue Organisation gründen lassen</h3>
+    <p>Der Eingeladene erhält eine E-Mail mit einem Registrierungslink. Bei der Registrierung legt er eine neue Organisation an und wird deren Administrator. Der Link ist 7 Tage gültig.</p>
+  </div>
+
+  <form method="POST" action="/einladungen/founder">
+    {#authenticityToken /}
+
+    <div class="form-section">
+      <cds-text-input
+        label="E-Mail-Adresse"
+        name="email"
+        type="email"
+        placeholder="z.B. vorstand@verein.de"
+        required>
+        <span slot="helper-text">Die E-Mail-Adresse des neuen Organisationsgründers</span>
+      </cds-text-input>
+    </div>
+
+    <div class="form-actions">
+      <button type="submit" class="cds-btn cds-btn-primary">
+        Einladung erstellen
+        <svg viewBox="0 0 32 32" width="16" height="16" fill="currentColor"><path d="M21 26H8a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h13v2H8v16h13Z"/><path d="M20 22a2 2 0 0 1 2-2h4v-4h2v4a2 2 0 0 1-2 2h-4v4h-2Zm2-10h4V8a2 2 0 0 0-2-2h-4V4h4a4 4 0 0 1 4 4v4h-6Z"/></svg>
+      </button>
+      <cds-button href="/einladungen" kind="secondary">
+        Abbrechen
+      </cds-button>
+    </div>
+  </form>
+</div>
+
+{#if flash:error}
+  <cds-inline-notification
+    kind="error"
+    title="Fehler"
+    subtitle="{flash:error}"
+    style="position: fixed; bottom: 1rem; right: 1rem;">
+  </cds-inline-notification>
+{/if}
+
+{/include}

--- a/app.fuggs.fuggs-app/src/main/resources/templates/InvitationResource/index.html
+++ b/app.fuggs.fuggs-app/src/main/resources/templates/InvitationResource/index.html
@@ -88,10 +88,18 @@
 
 <div class="page-header">
   <h1>Einladungen</h1>
-  <cds-button href="/einladungen/neu" kind="primary">
-    Neue Einladung
-    <svg slot="icon" viewBox="0 0 32 32" width="16" height="16" fill="currentColor"><path d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2z"/></svg>
-  </cds-button>
+  <div style="display: flex; gap: var(--cds-spacing-03);">
+    {#if isSuperAdmin}
+    <cds-button href="/einladungen/founder" kind="secondary">
+      Gründer einladen
+      <svg slot="icon" viewBox="0 0 32 32" width="16" height="16" fill="currentColor"><path d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2z"/></svg>
+    </cds-button>
+    {/if}
+    <cds-button href="/einladungen/neu" kind="primary">
+      Neue Einladung
+      <svg slot="icon" viewBox="0 0 32 32" width="16" height="16" fill="currentColor"><path d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2z"/></svg>
+    </cds-button>
+  </div>
 </div>
 
 {#if !pendingInvitations.isEmpty}

--- a/app.fuggs.fuggs-app/src/test/java/app/fuggs/member/service/KeycloakAdminServiceTest.java
+++ b/app.fuggs.fuggs-app/src/test/java/app/fuggs/member/service/KeycloakAdminServiceTest.java
@@ -110,7 +110,7 @@ class KeycloakAdminServiceTest
 		when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
 
 		// When
-		String userId = service.createUser(username, email, firstName, lastName, roles);
+		String userId = service.createUser(username, email, firstName, lastName, roles, "test-password");
 
 		// Then
 		assertEquals("user-123", userId);
@@ -128,7 +128,7 @@ class KeycloakAdminServiceTest
 
 		// When/Then
 		assertThrows(RuntimeException.class, () -> {
-			service.createUser("john.doe", "john@example.com", "John", "Doe", List.of("user"));
+			service.createUser("john.doe", "john@example.com", "John", "Doe", List.of("user"), "test-password");
 		});
 	}
 
@@ -142,7 +142,7 @@ class KeycloakAdminServiceTest
 			.thenReturn("https://keycloak.example.com/users/user-456");
 
 		// When
-		String userId = service.createUser("jane.doe", "jane@example.com", "Jane", "Doe", List.of());
+		String userId = service.createUser("jane.doe", "jane@example.com", "Jane", "Doe", List.of(), "test-password");
 
 		// Then
 		assertEquals("user-456", userId);
@@ -162,7 +162,7 @@ class KeycloakAdminServiceTest
 			.thenReturn("https://keycloak.example.com/users/user-789");
 
 		// When
-		String userId = service.createUser("bob.smith", "bob@example.com", "Bob", "Smith", null);
+		String userId = service.createUser("bob.smith", "bob@example.com", "Bob", "Smith", null, "test-password");
 
 		// Then
 		assertEquals("user-789", userId);
@@ -181,7 +181,7 @@ class KeycloakAdminServiceTest
 			.thenReturn("https://keycloak.example.com/admin/realms/test-realm/users/abc-123-def-456");
 
 		// When
-		String userId = service.createUser("test", "test@example.com", "Test", "User", List.of());
+		String userId = service.createUser("test", "test@example.com", "Test", "User", List.of(), "test-password");
 
 		// Then
 		assertEquals("abc-123-def-456", userId);
@@ -209,7 +209,7 @@ class KeycloakAdminServiceTest
 		when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
 
 		// When
-		service.createUser("test", "test@example.com", "Test", "User", List.of("new-role"));
+		service.createUser("test", "test@example.com", "Test", "User", List.of("new-role"), "test-password");
 
 		// Then
 		// Verify role was created
@@ -262,7 +262,7 @@ class KeycloakAdminServiceTest
 		when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
 
 		// When
-		String userId = service.createUser("multi", "multi@example.com", "Multi", "Role", roles);
+		String userId = service.createUser("multi", "multi@example.com", "Multi", "Role", roles, "test-password");
 
 		// Then
 		assertEquals("user-multi-role", userId);

--- a/app.fuggs.fuggs-app/src/test/java/app/fuggs/member/service/MemberKeycloakSyncServiceTest.java
+++ b/app.fuggs.fuggs-app/src/test/java/app/fuggs/member/service/MemberKeycloakSyncServiceTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -43,7 +45,7 @@ class MemberKeycloakSyncServiceTest
 	void shouldSyncMemberWithDefaultRoles()
 	{
 		// Given
-		when(keycloakAdminService.createUser(any(), any(), any(), any(), any()))
+		when(keycloakAdminService.createUser(any(), any(), any(), any(), any(), anyString(), anyBoolean()))
 			.thenReturn("kc-user-123");
 
 		// When
@@ -56,7 +58,9 @@ class MemberKeycloakSyncServiceTest
 			eq("john.doe@example.com"),
 			eq("John"),
 			eq("Doe"),
-			argThat(list -> list.size() == 1 && list.contains("user")));
+			argThat(list -> list.size() == 1 && list.contains("user")),
+			anyString(),
+			anyBoolean());
 	}
 
 	@Test
@@ -64,7 +68,7 @@ class MemberKeycloakSyncServiceTest
 	{
 		// Given
 		List<String> additionalRoles = List.of("admin", "moderator");
-		when(keycloakAdminService.createUser(any(), any(), any(), any(), any()))
+		when(keycloakAdminService.createUser(any(), any(), any(), any(), any(), anyString(), anyBoolean()))
 			.thenReturn("kc-user-456");
 
 		// When
@@ -80,14 +84,16 @@ class MemberKeycloakSyncServiceTest
 			argThat(list -> list.size() == 3
 				&& list.contains("user")
 				&& list.contains("admin")
-				&& list.contains("moderator")));
+				&& list.contains("moderator")),
+			anyString(),
+			anyBoolean());
 	}
 
 	@Test
 	void shouldHandleNullAdditionalRoles()
 	{
 		// Given
-		when(keycloakAdminService.createUser(any(), any(), any(), any(), any()))
+		when(keycloakAdminService.createUser(any(), any(), any(), any(), any(), anyString(), anyBoolean()))
 			.thenReturn("kc-user-789");
 
 		// When
@@ -100,14 +106,16 @@ class MemberKeycloakSyncServiceTest
 			any(),
 			any(),
 			any(),
-			argThat(list -> list.size() == 1 && list.contains("user")));
+			argThat(list -> list.size() == 1 && list.contains("user")),
+			anyString(),
+			anyBoolean());
 	}
 
 	@Test
 	void shouldPassCorrectUserDetailsToKeycloak()
 	{
 		// Given
-		when(keycloakAdminService.createUser(any(), any(), any(), any(), any()))
+		when(keycloakAdminService.createUser(any(), any(), any(), any(), any(), anyString(), anyBoolean()))
 			.thenReturn("kc-user-123");
 
 		// When
@@ -119,7 +127,9 @@ class MemberKeycloakSyncServiceTest
 			eq("john.doe@example.com"), // email
 			eq("John"), // firstName
 			eq("Doe"), // lastName
-			any());
+			any(),
+			anyString(),
+			anyBoolean());
 	}
 
 	@Test
@@ -133,7 +143,7 @@ class MemberKeycloakSyncServiceTest
 		memberWithDifferentUsername.setLastName("Smith");
 		memberWithDifferentUsername.setEmail("jane@example.com");
 
-		when(keycloakAdminService.createUser(any(), any(), any(), any(), any()))
+		when(keycloakAdminService.createUser(any(), any(), any(), any(), any(), anyString(), anyBoolean()))
 			.thenReturn("kc-user-555");
 
 		// When
@@ -145,6 +155,8 @@ class MemberKeycloakSyncServiceTest
 			eq("jane@example.com"), // email
 			eq("Jane"),
 			eq("Smith"),
-			any());
+			any(),
+			anyString(),
+			anyBoolean());
 	}
 }


### PR DESCRIPTION
## Summary

- **Password ignored on registration** — registration form collected a password but it was silently replaced with the hardcoded string `"password"`; now passed through to Keycloak
- **`emailVerified=false` blocked login** — all Keycloak-created users had email unverified; set to `true` since the invitation flow already validates the address
- **Root Bommel missing for UI-created orgs** — orgs created via super-admin UI or founder registration had no root Bommel, crashing the Bommel page; fixed in both `OrganizationResource` and `RegistrationService`
- **Founder invitation was dead code** — `GET/POST /einladungen/founder` added (super-admin only); `InvitationService.createFounderInvitation()` added; "Gründer einladen" button shown to super-admins on the invitations page
- **No production super-admin bootstrap** — added `fuggs.bootstrap.users.*.password` config props (default `"password"` for dev; override via env vars in prod)
- **DB wiped on restart** — added `quarkus-flyway`, `V1__initial_schema.sql`, and `%prod.quarkus.hibernate-orm.database.generation=none`
- **Admin-created members had no login path** — `MemberKeycloakSyncService` now sets a random UUID temporary password with `temporary=true`, forcing Keycloak to prompt for a new password on first login

## Known caveats

- Bootstrap still creates `maria` + `thomas` in production unless those usernames are overridden via env vars to match `admin` (idempotent skip)
- Flyway V1 migration column names are derived from entity analysis; should be validated against a real `drop-and-create` run before going live

## Test plan

- [ ] Register via invitation link — password from form should work
- [ ] Verify invited user can log in immediately (no email verification prompt)
- [ ] Create org via super-admin UI → navigate to `/bommels` → should not crash
- [ ] Super-admin sends founder invitation → registrant creates new org → root Bommel exists
- [ ] Admin creates member directly → member forced to set password on first Keycloak login
- [ ] Deploy with `%prod` profile → Flyway runs V1 migration → app starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)